### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,19 +1,17 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:3.3.0"
+        classpath "com.android.tools.build:gradle:3.3.3"
     }
 }
 
 repositories {
     maven { url "https://android-sdk.voxeet.com/release" }
-    maven { url "http://dl.bintray.com/voxeet/maven" }
     google()
     mavenCentral()
-    jcenter()
 }
 
 apply plugin: 'com.android.library'
@@ -48,8 +46,8 @@ android {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation "androidx.appcompat:appcompat:1.1.0"
-    implementation "androidx.annotation:annotation:1.1.0"
+    implementation "androidx.appcompat:appcompat:1.3.1"
+    implementation "androidx.annotation:annotation:1.2.0"
 
 
     //add by default the optional firebase dependency


### PR DESCRIPTION
As the center was discontinued, it was necessary to remove and was added mavenCentral (https://developer.android.com/studio/build/jcenter-migration)

This line is  `maven { url "http://dl.bintray.com/voxeet/maven" }`  is invalid
With this the android build is stuck because it cannot find the lib, causing the build to take up to hours to timeout and break the application



